### PR TITLE
Deployment hotfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,10 @@ RUN apt-get update && \
 
 WORKDIR /usr/src/app
 
-COPY package.json pnpm-lock.yaml ./
-
+COPY . .
 RUN npm install -g pnpm
 RUN pnpm install
 
-COPY . .
 
 # Accept Git commit hash as build arguments
 ARG GIT_COMMIT_SHA=unknown_full


### PR DESCRIPTION
Copy the whole project instead of only the package files before running pnpm install